### PR TITLE
Fix a bug when URL's Path starts with /

### DIFF
--- a/command/register.go
+++ b/command/register.go
@@ -75,7 +75,7 @@ func validateRouteForApp(requestedRoute string, app pluginmodels.GetAppModel, se
 		host = formatHost(r)
 		route := url.URL{
 			Host: host,
-			Path: "/" + r.Path,
+			Path: "/" + strings.TrimPrefix(r.Path, "/"),
 		}
 
 		if requested.Host == route.Host && strings.HasPrefix(requested.Path, route.Path) {

--- a/command/register_test.go
+++ b/command/register_test.go
@@ -264,6 +264,34 @@ var _ = Describe("Register", func() {
 				Expect(err).To(MatchError("route 'not-app-host.app-domain/app-path/metrics' is not bound to app 'app-name'"))
 			})
 
+			It("checks the route when domain is passed correctly", func() {
+				cliConnection := newMockCliConnection()
+				Expect(command.RegisterMetricsEndpoint(cliConnection, "app-name", "app-host.app-domain/app-path", "", true)).To(Succeed())
+				Expect(cliConnection.cliCommandsCalled).To(receiveCreateUserProvidedService(
+					"metrics-endpoint-app-host.app-domain-app-path",
+					"-l",
+					"metrics-endpoint://app-host.app-domain/app-path",
+				))
+			})
+
+			It("checks the route when app route starts with //", func() {
+				cliConnection := newMockCliConnection()
+
+				cliConnection.getAppResult.Routes = []plugin_models.GetApp_RouteSummary{{
+					Host: "app-host",
+					Domain: plugin_models.GetApp_DomainFields{
+						Name: "app-domain",
+					},
+					Path: "/app-path",
+				}}
+				Expect(command.RegisterMetricsEndpoint(cliConnection, "app-name", "app-host.app-domain/app-path", "", true)).To(Succeed())
+				Expect(cliConnection.cliCommandsCalled).To(receiveCreateUserProvidedService(
+					"metrics-endpoint-app-host.app-domain-app-path",
+					"-l",
+					"metrics-endpoint://app-host.app-domain/app-path",
+				))
+			})
+
 			It("parses routes without hosts correctly", func() {
 				cliConnection := newMockCliConnection()
 


### PR DESCRIPTION
CF Cli creates a path with a leading forward slash. This is failing when a user tries to map a route with a URL and a path.

CF Cli Steps to reproduce:

```
cf map-route APP_NAME example.com --hostname random --path env
cf register-metrics-endpoint APP_NAME random.example.com/env --insecure
```